### PR TITLE
Fix breaking change and file reader

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -74,10 +74,10 @@ func main() {
 
 		fmt.Println()
 		fmt.Printf("Inputs        Throttle: %3.0f%% ➔ %3.0f%%  Brake: %3.0f%% ➔ %3.0f%%  Clutch: %3.0f%%  Steering: %+3.0f°  FFB: %+0.3f\n",
-			client.Telemetry.ThrottlePedalPercent(),
-			client.Telemetry.ThrottlePercent(),
-			client.Telemetry.BrakePedalPercent(),
-			client.Telemetry.BrakePercent(),
+			client.Telemetry.ThrottleInputPercent(),
+			client.Telemetry.ThrottleOutputPercent(),
+			client.Telemetry.BrakeInputPercent(),
+			client.Telemetry.BrakeOutputPercent(),
 			client.Telemetry.ClutchActuationPercent(),
 			client.Telemetry.SteeringWheelAngleDegrees(),
 			client.Telemetry.SteeringWheelForceFeedback(),

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -73,13 +73,14 @@ func main() {
 		)
 
 		fmt.Println()
-		fmt.Printf("Inputs        Throttle: %3.0f%% ➔ %3.0f%%  Brake: %3.0f%% ➔ %3.0f%%  Clutch: %3.0f%%  Steering: %+3.0f°\n",
+		fmt.Printf("Inputs        Throttle: %3.0f%% ➔ %3.0f%%  Brake: %3.0f%% ➔ %3.0f%%  Clutch: %3.0f%%  Steering: %+3.0f°  FFB: %+0.3f\n",
 			client.Telemetry.ThrottlePedalPercent(),
 			client.Telemetry.ThrottlePercent(),
 			client.Telemetry.BrakePedalPercent(),
 			client.Telemetry.BrakePercent(),
 			client.Telemetry.ClutchActuationPercent(),
 			client.Telemetry.SteeringWheelAngleDegrees(),
+			client.Telemetry.SteeringWheelForceFeedback(),
 		)
 
 		fmt.Printf("Engine        Speed: %s rpm  %s  Energy recovery: %+3.03f\n",
@@ -228,8 +229,7 @@ func main() {
 		)
 
 		fmt.Println()
-		fmt.Printf("Unknowns      0x12C: %+3.05f  0x13E: %3d  0x13F: %3d  0x154: %+3.05f\n",
-			client.Telemetry.Unknown0x12C(),
+		fmt.Printf("Unknowns      0x13E: %3d  0x13F: %3d  0x154: %+3.05f\n",
 			client.Telemetry.Unknown0x13E(),
 			client.Telemetry.Unknown0x13F(),
 			client.Telemetry.Unknown0x154(),

--- a/internal/gttelemetry/gran_turismo_telemetry.go
+++ b/internal/gttelemetry/gran_turismo_telemetry.go
@@ -51,7 +51,7 @@ type GranTurismoTelemetry struct {
 	TransmissionGearRatio *GranTurismoTelemetry_GearRatio
 	VehicleId uint32
 	SteeringWheelAngleRadians float32
-	Unknown0x12c float32
+	SteeringWheelForceFeedback float32
 	TranslationalEnvelope *GranTurismoTelemetry_TranslationalEnvelope
 	ThrottleRaw uint8
 	BrakeRaw uint8
@@ -349,7 +349,7 @@ func (this *GranTurismoTelemetry) Read(io *kaitai.Stream, parent interface{}, ro
 		if err != nil {
 			return err
 		}
-		this.Unknown0x12c = float32(tmp49)
+		this.SteeringWheelForceFeedback = float32(tmp49)
 	}
 	tmp50, err := this.HasSectionB()
 	if err != nil {

--- a/internal/gttelemetry/gran_turismo_telemetry.go
+++ b/internal/gttelemetry/gran_turismo_telemetry.go
@@ -35,8 +35,8 @@ type GranTurismoTelemetry struct {
 	CalculatedMaxSpeed uint16
 	Flags *GranTurismoTelemetry_Flags
 	TransmissionGear *GranTurismoTelemetry_TransmissionGear
-	Throttle uint8
-	Brake uint8
+	ThrottleOutput uint8
+	BrakeInput uint8
 	Ignore1 []byte
 	RoadPlaneVector *GranTurismoTelemetry_Vector
 	RoadPlaneDistance uint32
@@ -53,8 +53,8 @@ type GranTurismoTelemetry struct {
 	SteeringWheelAngleRadians float32
 	SteeringWheelForceFeedback float32
 	TranslationalEnvelope *GranTurismoTelemetry_TranslationalEnvelope
-	ThrottleRaw uint8
-	BrakeRaw uint8
+	ThrottleInput uint8
+	BrakeOutput uint8
 	Unknown0x13e uint8
 	Unknown0x13f uint8
 	Unknown0x140 float32
@@ -251,12 +251,12 @@ func (this *GranTurismoTelemetry) Read(io *kaitai.Stream, parent interface{}, ro
 	if err != nil {
 		return err
 	}
-	this.Throttle = tmp31
+	this.ThrottleOutput = tmp31
 	tmp32, err := this._io.ReadU1()
 	if err != nil {
 		return err
 	}
-	this.Brake = tmp32
+	this.BrakeInput = tmp32
 	tmp33, err := this._io.ReadBytes(int(1))
 	if err != nil {
 		return err
@@ -372,7 +372,7 @@ func (this *GranTurismoTelemetry) Read(io *kaitai.Stream, parent interface{}, ro
 		if err != nil {
 			return err
 		}
-		this.ThrottleRaw = tmp53
+		this.ThrottleInput = tmp53
 	}
 	tmp54, err := this.HasSectionTilde()
 	if err != nil {
@@ -383,7 +383,7 @@ func (this *GranTurismoTelemetry) Read(io *kaitai.Stream, parent interface{}, ro
 		if err != nil {
 			return err
 		}
-		this.BrakeRaw = tmp55
+		this.BrakeOutput = tmp55
 	}
 	tmp56, err := this.HasSectionTilde()
 	if err != nil {

--- a/internal/kaitai/gran_turismo_telemetry.ksy
+++ b/internal/kaitai/gran_turismo_telemetry.ksy
@@ -95,12 +95,12 @@ seq:
   - id: transmission_gear
     type: transmission_gear
     -doc: Transmission gear selection
-  - id: throttle
+  - id: throttle_output
     type: u1
-    -doc: Throttle position (0 to 255)
-  - id: brake
+    -doc: Throttle output value after TCS applied (0 to 255)
+  - id: brake_input
     type: u1
-    -doc: Brake position (0 to 255)
+    -doc: Brake input value from controller (0 to 255)
   - id: ignore_1
     size: 1
     -doc: Field 0x93 is empty and ignored
@@ -152,14 +152,14 @@ seq:
     type: translational_envelope
     if: has_section_b
     -doc: Body forces along axes (-1 to 1)
-  - id: throttle_raw
+  - id: throttle_input
     type: u1
     if: has_section_tilde
-    -doc: Raw throttle percent from driver input
-  - id: brake_raw
+    -doc: Throttle input value from controller (0-255)
+  - id: brake_output
     type: u1
     if: has_section_tilde
-    -doc: Raw brake percent from driver input (live sessions only)
+    -doc: Brake output value after ABS applied (0-255) (live sessions only)
   - id: unknown0x13e
     type: u1
     if: has_section_tilde

--- a/internal/kaitai/gran_turismo_telemetry.ksy
+++ b/internal/kaitai/gran_turismo_telemetry.ksy
@@ -144,12 +144,10 @@ seq:
     type: f4
     if: has_section_b
     -doc: Steering wheel angular position in radians
-  - id: unknown0x12c
+  - id: steering_wheel_force_feedback
     type: f4
     if: has_section_b
-    -doc: |
-      Unkown value, possibly front axle slip angle related to drift scoring.
-      Increases in value when front end slip angle is high and resets to zero when the car spins out
+    -doc: Steering wheel force feedback signal (unverified)
   - id: translational_envelope
     type: translational_envelope
     if: has_section_b
@@ -157,11 +155,11 @@ seq:
   - id: throttle_raw
     type: u1
     if: has_section_tilde
-    -doc: Raw throttle percent from driver input, live sessions only
+    -doc: Raw throttle percent from driver input
   - id: brake_raw
     type: u1
     if: has_section_tilde
-    -doc: Raw brake percent from driver input, live sessions only
+    -doc: Raw brake percent from driver input (live sessions only)
   - id: unknown0x13e
     type: u1
     if: has_section_tilde
@@ -193,7 +191,7 @@ seq:
   - id: unknown0x154
     type: f4
     if: has_section_tilde
-    -doc: Unknown value
+    -doc: Unknown value, something related to vehicle motion
 types:
   header:
     doc: |

--- a/transformer.go
+++ b/transformer.go
@@ -107,12 +107,17 @@ func (t *transformer) BestLaptime() time.Duration {
 	return time.Duration(t.RawTelemetry.BestLaptime) * time.Millisecond
 }
 
-func (t *transformer) BrakePedalPercent() float32 {
-	return float32(t.RawTelemetry.BrakeRaw) / 2.55
+func (t *transformer) BrakeInputPercent() float32 {
+	return float32(t.RawTelemetry.BrakeInput) / 2.55
 }
 
+func (t *transformer) BrakeOutputPercent() float32 {
+	return float32(t.RawTelemetry.BrakeOutput) / 2.55
+}
+
+// To be deprecated in 2.0 release
 func (t *transformer) BrakePercent() float32 {
-	return float32(t.RawTelemetry.Brake) / 2.55
+	return float32(t.RawTelemetry.BrakeInput) / 2.55
 }
 
 func (t *transformer) CalculatedVmax() Vmax {
@@ -323,7 +328,7 @@ func (t *transformer) RotationEnvelope() RotationalEnvelope {
 	}
 }
 
-// To be deprecated in favor of RotationalEnvelope()
+// To be deprecated in 2.0 release in favor of RotationalEnvelope()
 func (t *transformer) RotationVector() SymmetryAxes {
 	rotation := t.RawTelemetry.RotationalEnvelope
 	if rotation == nil {
@@ -399,12 +404,17 @@ func (t *transformer) TelemetryFormat() telemetrysrc.TelemetryFormat {
 	return "unknown"
 }
 
-func (t *transformer) ThrottlePedalPercent() float32 {
-	return float32(t.RawTelemetry.ThrottleRaw) / 2.55
+func (t *transformer) ThrottleInputPercent() float32 {
+	return float32(t.RawTelemetry.ThrottleInput) / 2.55
 }
 
+func (t *transformer) ThrottleOutputPercent() float32 {
+	return float32(t.RawTelemetry.ThrottleOutput) / 2.55
+}
+
+// To be deprecated in 2.0 release
 func (t *transformer) ThrottlePercent() float32 {
-	return float32(t.RawTelemetry.Throttle) / 2.55
+	return float32(t.RawTelemetry.ThrottleOutput) / 2.55
 }
 
 func (t *transformer) TimeOfDay() time.Duration {

--- a/transformer.go
+++ b/transformer.go
@@ -575,10 +575,10 @@ func (t *transformer) VehicleHasOpenCockpit() bool {
 	return t.vehicle.OpenCockpit
 }
 
-func (t *transformer) VehicleID() int {
+func (t *transformer) VehicleID() uint32 {
 	t.updateVehicle()
 
-	return t.vehicle.CarID
+	return uint32(t.vehicle.CarID)
 }
 
 func (t *transformer) VehicleManufacturer() string {

--- a/transformer.go
+++ b/transformer.go
@@ -353,6 +353,10 @@ func (t *transformer) SteeringWheelAngleRadians() float32 {
 	return t.RawTelemetry.SteeringWheelAngleRadians
 }
 
+func (t *transformer) SteeringWheelForceFeedback() float32 {
+	return t.RawTelemetry.SteeringWheelForceFeedback
+}
+
 func (t *transformer) SuggestedGear() uint64 {
 	gear := t.RawTelemetry.TransmissionGear
 	if gear == nil {
@@ -511,10 +515,6 @@ func (t *transformer) TyreTemperatureCelsius() CornerSet {
 		RearLeft:   temperature.RearLeft,
 		RearRight:  temperature.RearRight,
 	}
-}
-
-func (t *transformer) Unknown0x12C() float32 {
-	return t.RawTelemetry.Unknown0x12c
 }
 
 func (t *transformer) Unknown0x13E() uint8 {

--- a/transformer_test.go
+++ b/transformer_test.go
@@ -1048,9 +1048,9 @@ func (suite *TransformerTestSuite) TestGetVehicleAspirationExpandedReturnsCorrec
 
 func (suite *TransformerTestSuite) TestGetVehicleIDReturnsCorrectValueWhenTelemetryHasKnownID() {
 	// Arrange
-	wantValue := 1234
+	wantValue := uint32(1234)
 	suite.transformer.vehicle = vehicles.Vehicle{}
-	suite.transformer.RawTelemetry.VehicleId = uint32(wantValue)
+	suite.transformer.RawTelemetry.VehicleId = wantValue
 
 	// Act
 	gotValue := suite.transformer.VehicleID()

--- a/transformer_test.go
+++ b/transformer_test.go
@@ -83,13 +83,25 @@ func (suite *TransformerTestSuite) TestBestLaptimeReturnsCorrectDuration() {
 	suite.Equal(wantValue, gotValue)
 }
 
-func (suite *TransformerTestSuite) TestBrakePedalPercentReturnsCorrectValue() {
+func (suite *TransformerTestSuite) TestBrakeInputPercentReturnsCorrectValue() {
 	// Arrange
 	wantValue := float32(84.31373)
-	suite.transformer.RawTelemetry.BrakeRaw = uint8(215)
+	suite.transformer.RawTelemetry.BrakeInput = uint8(215)
 
 	// Act
-	gotValue := suite.transformer.BrakePedalPercent()
+	gotValue := suite.transformer.BrakeInputPercent()
+
+	// Assert
+	suite.Equal(wantValue, gotValue)
+}
+
+func (suite *TransformerTestSuite) TestBrakeOutputPercentReturnsCorrectValue() {
+	// Arrange
+	wantValue := float32(84.31373)
+	suite.transformer.RawTelemetry.BrakeOutput = uint8(215)
+
+	// Act
+	gotValue := suite.transformer.BrakeOutputPercent()
 
 	// Assert
 	suite.Equal(wantValue, gotValue)
@@ -98,7 +110,7 @@ func (suite *TransformerTestSuite) TestBrakePedalPercentReturnsCorrectValue() {
 func (suite *TransformerTestSuite) TestBrakePercentReturnsCorrectValue() {
 	// Arrange
 	wantValue := float32(56.078434)
-	suite.transformer.RawTelemetry.Brake = uint8(143)
+	suite.transformer.RawTelemetry.BrakeInput = uint8(143)
 
 	// Act
 	gotValue := suite.transformer.BrakePercent()
@@ -795,25 +807,37 @@ func (suite *TransformerTestSuite) TestTelemetryFormatIndicatorsFIXME() {
 	}
 }
 
-func (suite *TransformerTestSuite) TestThrottlePercentReturnsCorrectValue() {
+func (suite *TransformerTestSuite) TestThrottleInputPercentReturnsCorrectValue() {
 	// Arrange
-	wantValue := float32(79.60784)
-	suite.transformer.RawTelemetry.Throttle = 203
+	wantValue := float32(37.64706)
+	suite.transformer.RawTelemetry.ThrottleInput = uint8(96)
 
 	// Act
-	gotValue := suite.transformer.ThrottlePercent()
+	gotValue := suite.transformer.ThrottleInputPercent()
 
 	// Assert
 	suite.Equal(wantValue, gotValue)
 }
 
-func (suite *TransformerTestSuite) TestThrottlePedalPercentReturnsCorrectValue() {
+func (suite *TransformerTestSuite) TestThrottleOutputPercentReturnsCorrectValue() {
 	// Arrange
 	wantValue := float32(37.64706)
-	suite.transformer.RawTelemetry.ThrottleRaw = uint8(96)
+	suite.transformer.RawTelemetry.ThrottleInput = uint8(96)
 
 	// Act
-	gotValue := suite.transformer.ThrottlePedalPercent()
+	gotValue := suite.transformer.ThrottleInputPercent()
+
+	// Assert
+	suite.Equal(wantValue, gotValue)
+}
+
+func (suite *TransformerTestSuite) TestThrottlePercentReturnsCorrectValue() {
+	// Arrange
+	wantValue := float32(79.60784)
+	suite.transformer.RawTelemetry.ThrottleOutput = 203
+
+	// Act
+	gotValue := suite.transformer.ThrottlePercent()
 
 	// Assert
 	suite.Equal(wantValue, gotValue)


### PR DESCRIPTION
- Fixed an issue where the file reader was returning telemetry packets with magic header bytes on the tail end of the data
- Fixed the return type of the transformer VehicleID() method